### PR TITLE
Fix env script variable and README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The Digital human blueprint has two components, the digital avatar deployment an
 * [Prerequisites](#prerequisites)
 * [Deployment](/deploy/)
 * [Customization](/customize/)
-* [Evaluation]((/evaluate/))
+* [Evaluation](/evaluate/)
 
 
 ## Prerequisites

--- a/print_env.sh
+++ b/print_env.sh
@@ -58,7 +58,7 @@ printf '%-32s: %s\n' NUMBAPRO_LIBDEVICE $NUMBAPRO_LIBDEVICE
 
 printf '%-32s: %s\n' CONDA_PREFIX $CONDA_PREFIX
 
-printf '%-32s: %s\n' PYTHON_PATH $PYTHON_PATH
+printf '%-32s: %s\n' PYTHONPATH $PYTHONPATH
 
 echo
 


### PR DESCRIPTION
## Summary
- fix evaluation link in README
- fix PYTHONPATH variable in `print_env.sh`

## Testing
- `bash print_env.sh > /tmp/env_output.txt && tail -n 5 /tmp/env_output.txt`

------
https://chatgpt.com/codex/tasks/task_e_6872698d0bb48333bc030fc0736639c3