### PR TITLE
Add simple lead monitoring tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,10 @@ Once you familiarize yourself with the blueprint, you may want to further custom
 
 #### System requirements
 Ubuntu 20.04 or 22.04 based machine, with sudo privileges
+
+### Lead Monitoring Script
+A helper script `monitor_leads.py` is included to watch a CSV file for new leads. Run it with:
+```bash
+python monitor_leads.py leads.csv --interval 10
+```
+

--- a/monitor_leads.py
+++ b/monitor_leads.py
@@ -1,0 +1,58 @@
+import csv
+import os
+import time
+import argparse
+from typing import List, Dict, Set
+
+
+def load_leads(path: str) -> List[Dict[str, str]]:
+    """Load leads from a CSV file."""
+    with open(path, newline='', encoding='utf-8') as f:
+        return list(csv.DictReader(f))
+
+
+def detect_new_leads(path: str, seen_ids: Set[str]) -> List[Dict[str, str]]:
+    """Return new leads not present in seen_ids and update seen_ids."""
+    if not os.path.exists(path):
+        return []
+    leads = load_leads(path)
+    new = []
+    for lead in leads:
+        lead_id = lead.get("id")
+        if lead_id and lead_id not in seen_ids:
+            seen_ids.add(lead_id)
+            new.append(lead)
+    return new
+
+
+def monitor(path: str, interval: float = 30.0) -> None:
+    """Continuously monitor the leads file for new entries."""
+    seen: Set[str] = set()
+    if os.path.exists(path):
+        for lead in load_leads(path):
+            if "id" in lead:
+                seen.add(lead["id"])
+
+    print(f"Monitoring {path} every {interval} seconds... Press Ctrl+C to stop.")
+    try:
+        while True:
+            time.sleep(interval)
+            new = detect_new_leads(path, seen)
+            if new:
+                print("New leads detected:")
+                for lead in new:
+                    print("-", lead)
+    except KeyboardInterrupt:
+        print("\nStopped monitoring.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Monitor a CSV file for new business leads")
+    parser.add_argument("file", help="Path to the leads CSV file")
+    parser.add_argument("--interval", type=float, default=30.0, help="Polling interval in seconds")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    monitor(args.file, args.interval)

--- a/tests/test_monitor_leads.py
+++ b/tests/test_monitor_leads.py
@@ -1,0 +1,25 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+import tempfile
+import csv
+from monitor_leads import detect_new_leads
+
+
+def test_detect_new_leads(tmp_path):
+    csv_path = tmp_path / "leads.csv"
+    # initial leads
+    with open(csv_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "name"])
+        writer.writeheader()
+        writer.writerow({"id": "1", "name": "Alice"})
+    seen = set()
+    new = detect_new_leads(str(csv_path), seen)
+    assert len(new) == 1
+    assert new[0]["name"] == "Alice"
+
+    # add another lead
+    with open(csv_path, "a", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=["id", "name"])
+        writer.writerow({"id": "2", "name": "Bob"})
+    new = detect_new_leads(str(csv_path), seen)
+    assert len(new) == 1
+    assert new[0]["name"] == "Bob"


### PR DESCRIPTION
## Summary
- add `monitor_leads.py` utility to watch a CSV file for new leads
- document the lead monitoring script in README
- test new `detect_new_leads` helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687323a535008333adeb3c56f13d9d5f